### PR TITLE
adding the ParaMonte library

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -487,6 +487,13 @@
   tags: back propagation coarray
   version: none
 
+- name: ParaMonte
+  github: cdslaborg/paramonte
+  description: ParaMonte is a well-tested general-purpose open-source high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in the 2018-standard-complaint Fortran programming language, currently with interfaces to the C/C++/Fortran/MATLAB/Python programming languages.
+  categories: numerical
+  tags: parallel mpi coarray monte carlo mcmc c cpp matlab python statistics bayesian stochastic optimization sampling integration machine learning
+  version: 1.0.0
+
 - name: bspline-fortran
   github: jacobwilliams/bspline-fortran
   description: Multidimensional B-Spline interpolation of data on a regular grid


### PR DESCRIPTION
This commit adds the ParaMonte library to the list of Fortran numerical libraries. ParaMonte is a well-tested general-purpose open-source high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in the 2018-standard-complaint Fortran programming language, currently with interfaces to the C/C++/Fortran/MATLAB/Python programming languages. The project's homepage and documentation is available at: https://www.cdslab.org/paramonte/